### PR TITLE
MQTT ringbuf size increased

### DIFF
--- a/platforms/bk7231n/bk7231n_os/beken378/func/lwip_intf/lwip-2.1.3/src/include/lwip/apps/mqtt_opts.h
+++ b/platforms/bk7231n/bk7231n_os/beken378/func/lwip_intf/lwip-2.1.3/src/include/lwip/apps/mqtt_opts.h
@@ -53,7 +53,7 @@ extern "C" {
  * Output ring-buffer size, must be able to fit largest outgoing publish message topic+payloads
  */
 #ifndef MQTT_OUTPUT_RINGBUF_SIZE
-#define MQTT_OUTPUT_RINGBUF_SIZE 2048 
+#define MQTT_OUTPUT_RINGBUF_SIZE 4096 
 #endif
 
 /**


### PR DESCRIPTION
MQTT ring buffer size increased to 4096. Published JSON requirres up to 2000 bytes. 