### PR TITLE
Enable xTimerPendFunctionCall in freeRtos

### DIFF
--- a/platforms/bk7231n/bk7231n_os/beken378/os/include/FreeRTOSConfig.h
+++ b/platforms/bk7231n/bk7231n_os/beken378/os/include/FreeRTOSConfig.h
@@ -130,6 +130,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelay					1
 #define INCLUDE_xTaskAbortDelay				1
 #define INCLUDE_xTaskGetCurrentTaskHandle	1
+#define INCLUDE_xTimerPendFunctionCall      1
 
 #define configMAX_SYSCALL_INTERRUPT_PRIORITY  191 /* equivalent to 0xb0, or priority 11. */
 


### PR DESCRIPTION
Enable a function call in freertos which allows us to cause a function to be called from the timer task