### PR TITLE
Increase space for WPA key

### DIFF
--- a/platforms/bk7231n/bk7231n_os/beken378/func/include/wlan_ui_pub.h
+++ b/platforms/bk7231n/bk7231n_os/beken378/func/include/wlan_ui_pub.h
@@ -140,7 +140,7 @@ typedef struct _network_InitTypeDef_st
 {
     char wifi_mode;               /**< DHCP mode: @ref wlanInterfaceTypedef.*/
     char wifi_ssid[33];           /**< SSID of the wlan needs to be connected.*/
-    char wifi_key[64];            /**< Security key of the wlan needs to be connected, ignored in an open system.*/
+    char wifi_key[65];            /**< Security key of the wlan needs to be connected, ignored in an open system.*/
     char local_ip_addr[16];       /**< Static IP configuration, Local IP address. */
     char net_mask[16];            /**< Static IP configuration, Netmask. */
     char gateway_ip_addr[16];     /**< Static IP configuration, Router IP address. */


### PR DESCRIPTION
This is the first part of a fix for openshwprojects/OpenBK7231T_App#553.
I have tested this with a CB3S module.