### PR TITLE
UART2 Interrupt reading repair

### DIFF
--- a/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
+++ b/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
@@ -758,8 +758,8 @@ void uart2_isr(void)
     if(status & (RX_FIFO_NEED_READ_STA | UART_RX_STOP_END_STA))
     {
 	#if (!CFG_SUPPORT_RTT)
-		//20241119 XJIKKA if ATE_APP_FUN is not tested, reading UART2 is not functional. 
-		//uart_read_fifo_frame() clears the FIFO_RD_READY flag and therefore further reading is not possible.
+		//20241119 XJIKKA ATE_APP_FUN and get_ate_mode_state() were not checked, 
+		//therefore uart_read_fifo_frame() clears FIFO_RD_READY flag and further reading was not possible.
 		#if ATE_APP_FUN
 			if (get_ate_mode_state())
 			{

--- a/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
+++ b/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
@@ -758,12 +758,14 @@ void uart2_isr(void)
     if(status & (RX_FIFO_NEED_READ_STA | UART_RX_STOP_END_STA))
     {
 	#if (!CFG_SUPPORT_RTT)
-          #if ATE_APP_FUN
-            if (get_ate_mode_state())
-            {
+		//20241119 XJIKKA if ATE_APP_FUN is not tested, reading UART2 is not functional. 
+		//uart_read_fifo_frame() clears the FIFO_RD_READY flag and therefore further reading is not possible.
+		#if ATE_APP_FUN
+        if (get_ate_mode_state())
+		{
 		uart_read_fifo_frame(UART2_PORT, uart[UART2_PORT].rx);
-            }
-          #endif
+		}
+		#endif
 	#endif
 
 		if (uart_receive_callback[1].callback != 0)

--- a/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
+++ b/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
@@ -758,7 +758,12 @@ void uart2_isr(void)
     if(status & (RX_FIFO_NEED_READ_STA | UART_RX_STOP_END_STA))
     {
 	#if (!CFG_SUPPORT_RTT)
+          #if ATE_APP_FUN
+            if (get_ate_mode_state())
+            {
 		uart_read_fifo_frame(UART2_PORT, uart[UART2_PORT].rx);
+            }
+          #endif
 	#endif
 
 		if (uart_receive_callback[1].callback != 0)

--- a/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
+++ b/platforms/bk7231n/bk7231n_os/beken378/driver/uart/uart_bk.c
@@ -761,10 +761,10 @@ void uart2_isr(void)
 		//20241119 XJIKKA if ATE_APP_FUN is not tested, reading UART2 is not functional. 
 		//uart_read_fifo_frame() clears the FIFO_RD_READY flag and therefore further reading is not possible.
 		#if ATE_APP_FUN
-        if (get_ate_mode_state())
-		{
-		uart_read_fifo_frame(UART2_PORT, uart[UART2_PORT].rx);
-		}
+			if (get_ate_mode_state())
+			{
+				uart_read_fifo_frame(UART2_PORT, uart[UART2_PORT].rx);
+			}
 		#endif
 	#endif
 


### PR DESCRIPTION
Fix bug when reading UART2 via interrupt in SDK.
Finally I found the problem with UART2 in SDK. Now UART2 works OK. ATE_APP_FUN and get_ate_mode_state() were not checked, therefore uart_read_fifo_frame() clears FIFO_RD_READY flag and further reading was not possible.