### PR TITLE
clear pending ICU interrupts before enabling global IRQ/FIQ (fix rare hang after deep-sleep wake)

### DIFF
--- a/platforms/bk7231n/bk7231n_os/beken378/driver/intc/intc.c
+++ b/platforms/bk7231n/bk7231n_os/beken378/driver/intc/intc.c
@@ -362,6 +362,20 @@ void intc_init(void)
     *((volatile uint32_t *)0x400014) = (uint32_t)&do_dabort;
     *((volatile uint32_t *)0x400018) = (uint32_t)&do_reserved;
 
+    /*
+     * Deep-sleep wakeup is not a full cold boot: some interrupt status bits can
+     * remain set. If we enable global IRQ/FIQ here while a pending interrupt is
+     * already latched, we may enter IRQ/FIQ handlers before the OS/heap is ready,
+     * and get stuck very early in boot (no further logs after bk_misc_init_start_type).
+     *
+     * Clear any pending interrupt status before enabling sources.
+     */
+    {
+        UINT32 clr = 0xFFFFFFFF;
+        icu_ctrl(CMD_CLR_INTR_STATUS, &clr);
+        icu_ctrl(CMD_CLR_INTR_RAW_STATUS, &clr);
+    }
+
     intc_enable(FIQ_MAC_GENERAL);
     intc_enable(FIQ_MAC_PROT_TRIGGER);
 


### PR DESCRIPTION
  ## Context / Problem

  In a door sensor use case the device spends most of its time in deep sleep and wakes up frequently via GPIO (door
  open/close). Under stress (rapid open/close cycles) the firmware would sometimes hang very early during boot.

  Observed symptoms:
  - The last reliable UART log line is: `bk_misc_init_start_type 3 3`
  - The next expected line (FreeRTOS heap init) such as `prvHeapInit-start ...` never appears
  - This indicates the start type detection finished, but the system gets stuck before completing `func_init_basic()` /
  before the heap is initialized.

  ## Root Cause Analysis

  A deep-sleep wake is not a fully cold boot. Some ICU interrupt status bits can remain latched/pending after wake-up.

  During the boot path, `intc_init()` enables the ICU global IRQ/FIQ relatively early. If any interrupt is already
  pending at that moment, the CPU may enter IRQ/FIQ handlers before the OS/heap is ready, which can lead to an
  unrecoverable early-boot hang (no further logs after `bk_misc_init_start_type`).

  ## Fix

  In `intc_init()`, clear any pending ICU interrupt status **before** enabling interrupt sources and global IRQ/FIQ:
  - `CMD_CLR_INTR_STATUS`
  - `CMD_CLR_INTR_RAW_STATUS`

  This prevents immediate entry into interrupt handlers during the extremely early boot stage after deep-sleep wake.

  ## Changes

  - `platforms/bk7231n/bk7231n_os/beken378/driver/intc/intc.c`
    - Add ICU pending interrupt clear at the beginning of `intc_init()` (before enabling global IRQ/FIQ)
    - Add a comment explaining the deep-sleep wake scenario and why this is needed

  ## Test Plan

  - Stress test: rapidly toggle door open/close to trigger deep-sleep wake >= 100 cycles (Set a short time to deep-sleep, approximately 3 seconds.)
  - Verify UART logs: no more cases where output stops at `bk_misc_init_start_type 3 3` and heap init log is missing
  - Verify runtime behavior: wake -> advertise -> sleep remains stable over long runs without hangs/resets

  ## Risk / Impact

  - Minimal change: only clears pending ICU interrupt flags before enabling interrupts
  - No behavioral change for cold boot; improves stability for deep-sleep wake scenarios